### PR TITLE
Fix epoch comparison and differences. See #44

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The AstroTime.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2016: Helge Eichhorn.
+> Copyright (c) 2016-2019: Helge Eichhorn and the AstroTime.jl contributors.
 > 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
   - julia_version: 1
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:

--- a/src/Epochs.jl
+++ b/src/Epochs.jl
@@ -66,6 +66,14 @@ using ..Periods
 const J2000_TO_JULIAN = 2.451545e6days
 const J2000_TO_MJD = 51544.5days
 
+@inline function two_sum(a, b)
+    hi = a + b
+    a1 = hi - b
+    b1 = hi - a1
+    lo = (a - a1) + (b - b1)
+    hi, lo
+end
+
 struct Epoch{S, T} <: Dates.AbstractDateTime
     epoch::Int64
     offset::T
@@ -76,17 +84,12 @@ struct Epoch{S, T} <: Dates.AbstractDateTime
 end
 
 function Epoch{S}(epoch::Int64, offset, ts_offset, Δt) where S
-    sum = offset + Δt
+    sum, residual = two_sum(offset, Δt)
 
     if !isfinite(sum)
         offset′ = sum
         epoch′ = sum < 0 ? typemin(Int64) : typemax(Int64)
     else
-        o′ = sum - Δt
-        d′ = sum - o′
-        Δ0 = offset - o′
-        Δd = Δt - d′
-        residual = Δ0 + Δd
         dl = floor(Int64, sum)
         offset′ = (sum - dl) + residual
         epoch′ = epoch + dl
@@ -134,13 +137,7 @@ function Epoch{S}(jd1::T, jd2::T=zero(T), args...; origin=:j2000) where {S, T<:N
     jd1 *= SECONDS_PER_DAY
     jd2 *= SECONDS_PER_DAY
 
-    sum = jd1 + jd2
-
-    o′ = sum - jd2
-    d′ = sum - o′
-    Δ0 = jd1 - o′
-    Δd = jd2 - d′
-    residual = Δ0 + Δd
+    sum, residual = two_sum(jd1, jd2)
     epoch = floor(Int64, sum)
     offset = (sum - epoch) + residual
 
@@ -289,12 +286,7 @@ function Epoch{S}(date::Date, time::Time, args...) where S
     seconds = second(Float64, time)
     ts_offset = tai_offset(S, date, time, args...)
 
-    sum = seconds + ts_offset
-    s′ = sum - ts_offset
-    t′ = sum - s′
-    Δs = seconds  - s′
-    Δt = ts_offset - t′
-    residual = Δs + Δt
+    sum, residual = two_sum(seconds, ts_offset)
     dl = floor(Int64, sum)
 
     offset = (sum - dl) + residual
@@ -462,9 +454,15 @@ end
 Epoch{S, T}(ep::Epoch{S, T}) where {S, T} = ep
 
 function isapprox(a::Epoch, b::Epoch; atol::Real=0, rtol::Real=atol>0 ? 0 : √eps())
-    a.epoch == b.epoch &&
-    isapprox(a.offset, b.offset; atol=atol, rtol=rtol) &&
-    isapprox(a.ts_offset, b.ts_offset; atol=atol, rtol=rtol)
+    sum_a, residual_a = two_sum(a.ts_offset, a.offset)
+    epoch_a = a.epoch + floor(Int64, sum_a)
+    offset_a = (sum_a - epoch_a) + residual_a
+
+    sum_b, residual_b = two_sum(b.ts_offset, b.offset)
+    epoch_b = b.epoch + floor(Int64, sum_b)
+    offset_b = (sum_b - epoch_b) + residual_b
+
+    epoch_a == epoch_b && isapprox(offset_a, offset_b; atol=atol, rtol=rtol)
 end
 
 function ==(a::Epoch, b::Epoch)
@@ -489,9 +487,9 @@ julia> UTCEpoch(2018, 2, 6, 20, 45, 20.0) - UTCEpoch(2018, 2, 6, 20, 45, 0.0)
 20.0 seconds
 ```
 """
--(a::Epoch, b::Epoch) = ((a.epoch - b.epoch) +
-                         (a.offset - b.offset) +
-                         (a.ts_offset - b.ts_offset)) * seconds
+-(a::Epoch, b::Epoch) = ((a.offset - b.offset) +
+                         (a.ts_offset - b.ts_offset) +
+                         (a.epoch - b.epoch)) * seconds
 
 # Generate aliases for all defined time scales so we can use
 # e.g. `TTEpoch` instead of `Epoch{TT}`

--- a/src/Epochs.jl
+++ b/src/Epochs.jl
@@ -432,7 +432,7 @@ julia> ep = TAIEpoch(2000,1,1)
 2000-01-01T00:00:00.000 TAI
 
 julia> TTEpoch(32.184, ep)
-2000-01-01T00:00:32.184 TAI
+2000-01-01T00:00:32.184 TT
 ```
 """
 function Epoch{S2}(Δtai, ep::Epoch{S1}) where {S1, S2}

--- a/src/leapseconds.jl
+++ b/src/leapseconds.jl
@@ -67,6 +67,7 @@ for (ep, offset, dep, rate) in zip(EPOCHS, OFFSETS, DRIFT_EPOCHS, DRIFT_RATES)
 end
 
 @inline function insideleap(ep::UTCEpoch)
+    ep = TAIEpoch(ep)
     offset = findoffset(ep)
     offset === nothing && return false
 
@@ -74,6 +75,7 @@ end
 end
 
 @inline function getleap(ep::UTCEpoch)
+    ep = TAIEpoch(ep)
     offset = findoffset(ep)
     offset === nothing && return 0.0
 

--- a/src/offsets.jl
+++ b/src/offsets.jl
@@ -95,7 +95,6 @@ Returns the difference TDB-TAI in seconds at the epoch `ep` for an observer on E
 ### Arguments ###
 
 - `ep`: Current epoch
-- `ut`: Universal time (UT1, fraction of one day)
 - `elong`: Longitude (east positive, radians)
 - `u`: Distance from Earth's spin axis (km)
 - `v`: Distance north of equatorial plane (km)

--- a/test/epochs.jl
+++ b/test/epochs.jl
@@ -7,6 +7,17 @@
         ep += 10000centuries
         @test ep.epoch == value(seconds(10000centuries))
         @test ep.offset ≈ 2eps()
+
+        # Issue 44
+        elong1 = 0.0
+        elong2 = π
+        u = 6371.0
+        tai = TAIEpoch(2000, 1, 1)
+        Δtdb = tai_offset(TDB, tai, elong2, u, 0.0) - tai_offset(TDB, tai, elong1, u, 0.0)
+        tdb1 = TDBEpoch(tai, elong1, u, 0.0)
+        tdb2 = TDBEpoch(tai, elong2, u, 0.0)
+        @test value(tdb2 - tdb1) ≈ Δtdb
+        @test tdb1 != tdb2
     end
     @testset "Parsing" begin
         @test TAIEpoch("2000-01-01T00:00:00.000") == TAIEpoch(2000, 1, 1)
@@ -78,8 +89,8 @@
         @test tt - J2000_EPOCH == 0.0seconds
     end
     @testset "Accessors" begin
-        @test JULIAN_EPOCH - Inf * seconds == PAST_INFINITY
-        @test JULIAN_EPOCH + Inf * seconds == FUTURE_INFINITY
+        @test TAIEpoch(JULIAN_EPOCH - Inf * seconds) == PAST_INFINITY
+        @test TAIEpoch(JULIAN_EPOCH + Inf * seconds) == FUTURE_INFINITY
         @test string(PAST_INFINITY) == "-5877490-03-03T00:00:00.000 TAI"
         @test string(FUTURE_INFINITY) == "5881610-07-11T23:59:59.999 TAI"
         ep = UTCEpoch(2018, 2, 6, 20, 45, 59.371)

--- a/test/offsets.jl
+++ b/test/offsets.jl
@@ -19,7 +19,7 @@ import ERFA
     end
     @testset "TDB" begin
         ep = UTCEpoch(2000, 1, 1)
-        @test TDBEpoch(ep) ≈ TDBEpoch(ep, 0.0, 0.0, 0.0)
+        @test TDBEpoch(ep) ≈ TDBEpoch(ep, 0.0, 0.0, 0.0) rtol=1e-4
         jd1, jd2 = value.(julian_twopart(ep))
         ut = fractionofday(UT1Epoch(ep))
         elong, u, v = abs.(randn(3)) * 1000

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ end
         @test string(SCET) == "SCET"
         @test typeof(SCET) == SCETType
         scet = SCETEpoch(2000, 1, 1, 0, 8, 19.10478383615643, astronomical_unit)
-        @test SCETEpoch(2000, 1, 1, 0, 8, 19.10478383615643, astronomical_unit) ≈ utc
+        @test TAIEpoch(scet) ≈ TAIEpoch(utc)
         @test SCETEpoch(value(j2000(scet)), 0.0, astronomical_unit) ≈ scet
     end
 end


### PR DESCRIPTION
@bgodard Thanks for bringing this up! I believe this is the fix for the issue you mention in #44. The time scale offset needs to be included in comparisons and difference calculations of epoch.

Please check whether this approach makes sense conceptually.