### PR TITLE
Remove implicit floats in definition of `AstroPeriod`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AstroTime"
 uuid = "c61b5328-d09d-5e37-a9a8-0eb41c39009c"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Periods.jl
+++ b/src/Periods.jl
@@ -11,13 +11,13 @@ export AstroPeriod, TimeUnit,
     SECONDS_PER_YEAR,
     SECONDS_PER_CENTURY
 
-const SECONDS_PER_MINUTE   = 60
-const SECONDS_PER_HOUR     = 60 * SECONDS_PER_MINUTE
-const SECONDS_PER_DAY      = 24 * SECONDS_PER_HOUR
+const SECONDS_PER_MINUTE   =        60                       |> Int64
+const SECONDS_PER_HOUR     =        60  * SECONDS_PER_MINUTE |> Int64
+const SECONDS_PER_DAY      =        24  * SECONDS_PER_HOUR   |> Int64
 # Julian year, turns out to be an integer number of seconds in a year
 # despite it containing a fraction of a day
-const SECONDS_PER_YEAR     = (365+1//4) * SECONDS_PER_DAY |> Integer
-const SECONDS_PER_CENTURY  = 100 * SECONDS_PER_YEAR
+const SECONDS_PER_YEAR     = (365+1//4) * SECONDS_PER_DAY    |> Int64
+const SECONDS_PER_CENTURY  =       100  * SECONDS_PER_YEAR   |> Int64
 
 """
 All time units are subtypes of the abstract type `TimeUnit`.

--- a/src/Periods.jl
+++ b/src/Periods.jl
@@ -11,11 +11,13 @@ export AstroPeriod, TimeUnit,
     SECONDS_PER_YEAR,
     SECONDS_PER_CENTURY
 
-const SECONDS_PER_MINUTE   = 60.0
-const SECONDS_PER_HOUR     = 60.0 * 60.0
-const SECONDS_PER_DAY      = 60.0 * 60.0 * 24.0
-const SECONDS_PER_YEAR     = 60.0 * 60.0 * 24.0 * 365.25
-const SECONDS_PER_CENTURY  = 60.0 * 60.0 * 24.0 * 365.25 * 100.0
+const SECONDS_PER_MINUTE   = 60
+const SECONDS_PER_HOUR     = 60 * SECONDS_PER_MINUTE
+const SECONDS_PER_DAY      = 24 * SECONDS_PER_HOUR
+# Julian year, turns out to be an integer number of seconds in a year
+# despite it containing a fraction of a day
+const SECONDS_PER_YEAR     = (365+1//4) * SECONDS_PER_DAY |> Integer
+const SECONDS_PER_CENTURY  = 100 * SECONDS_PER_YEAR
 
 """
 All time units are subtypes of the abstract type `TimeUnit`.
@@ -46,7 +48,7 @@ const centuries = Century()
 
 Base.broadcastable(u::TimeUnit) = Ref(u)
 
-factor(::Second) = 1.0
+factor(::Second) = 1
 factor(::Minute) = SECONDS_PER_MINUTE
 factor(::Hour) = SECONDS_PER_HOUR
 factor(::Day) = SECONDS_PER_DAY

--- a/test/periods.jl
+++ b/test/periods.jl
@@ -103,4 +103,3 @@
     @test (1:3) * seconds === seconds * (1:3)
     @test (1:3) * seconds isa AbstractRange
 end
-


### PR DESCRIPTION
Should solve #68 :crossed_fingers:
Probably should bump patch version if we merge this